### PR TITLE
Fix library typo in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 
 **Tornado** is a framework for data stream mining, implemented in Python. The framework includes various incremental/online learning algorithms as well as concept drift detection methods.
 
-You must have Python 3.5 or above (either 32-bit or 64-bit) on your system to run the framework without any error. Note that the **numpy**, **scipy**, **mathplotlib**, and **pympler** packages are used in the Tornado implementations. You may use the `pip` command in order to install these packages, for example:
+You must have Python 3.5 or above (either 32-bit or 64-bit) on your system to run the framework without any error. Note that the **numpy**, **scipy**, **matplotlib**, and **pympler** packages are used in the Tornado implementations. You may use the `pip` command in order to install these packages, for example:
 
 ```bash
 pip install numpy


### PR DESCRIPTION
The plotting library `Matplotlib` was mentioned as `Mathplotlib` in the Readme file. Fixed that.